### PR TITLE
Remove ignore vendor from psalm config

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -7,8 +7,5 @@
 >
     <projectFiles>
         <directory name="src" />
-        <ignoreFiles>
-            <directory name="vendor" />
-        </ignoreFiles>
     </projectFiles>
 </psalm>


### PR DESCRIPTION
In configuration already specified directory `/src` for anylize. Ignore `/vendor` not required.