### PR TITLE
Remove useless flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The package ...
 The package could be installed with composer:
 
 ```shell
-composer require yiisoft/_____ --prefer-dist
+composer require yiisoft/_____
 ```
 
 ## General usage


### PR DESCRIPTION
It's useless because composer uses `dist` by default. 
https://getcomposer.org/doc/03-cli.md#install-i

> There are two ways of downloading a package: `source` and `dist`. Composer uses `dist` by default