### PR TITLE
Disable phpdoc separation in StyleCI

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -56,7 +56,6 @@ enabled:
   - phpdoc_order
   - phpdoc_property
   - phpdoc_scalar
-  - phpdoc_separation
   - phpdoc_singular_inheritdoc
   - phpdoc_trim
   - phpdoc_trim_consecutive_blank_line_separation


### PR DESCRIPTION
It is necessary to prevent such PRs: https://github.com/yiisoft/yii-debug-api/commit/2debd5772e3476670475cde8be8ecb8be573cf0b