### PR TITLE
Add concurrency configuration to GitHub Actions

### DIFF
--- a/.github/workflows/bc.yml_
+++ b/.github/workflows/bc.yml_
@@ -4,6 +4,10 @@ on:
 
 name: backwards compatibility
 
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   roave_bc_check:
     uses: yiisoft/actions/.github/workflows/bc.yml@master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,10 @@ on:
 
 name: build
 
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   phpunit:
     uses: yiisoft/actions/.github/workflows/phpunit.yml@master

--- a/.github/workflows/composer-require-checker.yml
+++ b/.github/workflows/composer-require-checker.yml
@@ -23,6 +23,10 @@ on:
 
 name: Composer require checker
 
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   composer-require-checker:
     uses: yiisoft/actions/.github/workflows/composer-require-checker.yml@master

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -19,6 +19,10 @@ on:
 
 name: mutation test
 
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   mutation:
     uses: yiisoft/actions/.github/workflows/roave-infection.yml@master

--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -11,6 +11,10 @@ on:
 
 name: rector
 
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   rector:
     uses: yiisoft/actions/.github/workflows/rector.yml@master

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -21,6 +21,10 @@ on:
 
 name: static analysis
 
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   psalm:
     uses: yiisoft/actions/.github/workflows/psalm.yml@master


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌

`group: ${{ github.head_ref || github.run_id }}` — in PR will be use `head_ref` (available in PR only), otherwise `run_id ` (unique run ID, so never canceling).
  
`cancel-in-progress: true` —  cancel any currently running workflow in the same concurrency group.

⚠ It would be good to test in a real package first.