### PR TITLE
Run rector in last version of PHP

### DIFF
--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -20,4 +20,4 @@ jobs:
       os: >-
         ['ubuntu-latest']
       php: >-
-        ['8.1']
+        ['8.2']


### PR DESCRIPTION
Rector must be runned in last version of PHP, because code of package can container code more later versions PHP than minimal required.